### PR TITLE
Add links for 4.5.18

### DIFF
--- a/download/index.rst
+++ b/download/index.rst
@@ -3,11 +3,18 @@
 Download
 ========
 
+Releases
+--------
+
 GMT is available on Windows, macOS and Linux. Source and binary packages are provided
 from `GitHub <https://github.com/GenericMappingTools/gmt/releases>`__:
 
 * `GMT 6.0.0rc4 (release candidate) <https://github.com/GenericMappingTools/gmt/releases/tag/6.0.0rc4>`__
 * `GMT 5.4.5 (stable) <https://github.com/GenericMappingTools/gmt/releases/tag/5.4.5>`__
+* `GMT 4.5.18 (final) <https://github.com/GenericMappingTools/gmt/wiki/GMT-4.5.18>`__
+
+Mirrors
+-------
 
 You may also get GMT from any of the GMT FTP mirrors.
 Try the site that is closest to you to minimize transmission times.
@@ -25,6 +32,9 @@ TENET, Tertiary Education & Research Networks, SOUTH AFRICA     ftp://gmt.mirror
 Univ. of Sci. & Tech. of China, Hefei, CHINA                    http://mirrors.ustc.edu.cn/gmt
 Tokai U, Shizuoka, JAPAN                                        http://www.scc.u-tokai.ac.jp/gmt
 =============================================================== =============================================================
+
+Install
+-------
 
 See the `install guide`_ for instructions and to make sure you have all required
 dependencies installed.


### PR DESCRIPTION
Add links for 4.5.18 and also separate the download page into sections to make it more readable.

screenshot:
![image](https://user-images.githubusercontent.com/3974108/66160795-e8174500-e5f8-11e9-8fee-1db74ac679b9.png)
