### PR TITLE
Add FOSS4G PyGMT workshop to front page news

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -71,6 +71,7 @@
 
                <ul>
                <li>AGU2019: <a href="https://www.agu.org/Events/SCIWS4-Generic-Mapping-Tools">Become a GMT contributor even if you can't code!</a></li>
+               <li>FOSS4G Oceania 2019: <a href="https://2019.foss4g-oceania.org/schedule/2019-11-12?sessionId=SPGUQV">PyGMT for geoscientists - A PyData compatible package for analyzing and plotting time-series and gridded data</a></li>
                </ul>
 
                <p>


### PR DESCRIPTION
I guess we forgot to add it to the front page.