### PR TITLE
Replace Discourse logo with "Forum"

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -68,14 +68,14 @@ html_theme_options = {
 html_context = {
     "social_links": [
         (
+            '<strong>Forum</strong>',
+            "Forum",
+            "https://forum.generic-mapping-tools.org/",
+        ),
+        (
             '<i class="fab fa-github fa-lg"></i>',
             "GitHub",
             "https://github.com/GenericMappingTools",
-        ),
-        (
-            '<i class="fab fa-discourse fa-lg"></i>',
-            "Forum",
-            "https://forum.generic-mapping-tools.org/",
         ),
         (
             '<i class="fab fa-youtube fa-lg"></i>',


### PR DESCRIPTION
The logo isn't readily recognizable so some users might have a hard time
finding the link to the forum. Leave it in the "social_icons" section so
that the link is opened in a new tab instead.

As suggested by @KristofKoch [in the forum](https://forum.generic-mapping-tools.org/t/visibility-of-forum-in-site-navigation-posting-rules/266).