### PR TITLE
Synchronize workshops with index

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -79,7 +79,7 @@
                <h2>Upcoming workshops</h2>
 
                <ul>
-               <li><strong>2020</strong>: The Generic Mapping Tools for Geodesy.</li>
+               <li><strong>2020</strong>: Making Maps and Movies.</li>
                </ul>
 
                <p>


### PR DESCRIPTION
The front page was mentioning geodesy but the first workshop is on map and movie making.