### PR TITLE
WIP: Add a raw changelog for 6.1 to website

### DIFF
--- a/Release_6.1.html
+++ b/Release_6.1.html
@@ -1,0 +1,64 @@
+<html>
+  <pre>
+GMT 6.1 ChangeLog
+
+Apart from bug fixes and general improvements across GMT, here are specifics
+on new features provided in 6.1.  Note: Some are only available in modern mode.
+
+General changes:
+    Updated and tiled remote data sets: Earth relief, masks, day/night imagery
+    Add MVT (Mapbox Vector Tile) as another GDAL URL dataset
+    Let gmt.history, gmt.conf, and gmt.cpt be hierarchical and separate for panels and figures in modern mode
+    Use list of keywords instead of bit-sum for MAP_ANNOT_OBLIQUE
+    Let the macOS bundle be built with OpenMP
+    Let GMT recognize MATLAB headers/comments via multiple IO_HEADER_MARKER characters
+    Let a signed grid cross size mean centered or asymmetrical grid ticks
+    Add modifier +v for a vertical oblique Equator in -JO
+    New -B modifier +i for internal frame annotations
+    New -B modifier +f to turn on fancy geographic annotations
+    New polar projection modifiers and capabilities
+    Revise verbosity default levels and their names and abbreviations
+    Add Web-Mercator as new sphere selection
+    Explore adding long-format GMT options
+    Allow both -i and -o to specify an open-ended list of columns to end of record
+    API improvements to support GMT/MATLAB, pyGMT, and GMT.jl environments
+    Several new high-resolution movies now moved to new YouTube GMT Collection
+
+New Common Options:
+    -l: Add auto legend entries from plot, plot3d, *contour in modern mode
+    -q: Select specific input or output data rows
+
+New Modules:
+
+    batch: Automate batch job processing
+    grdmix: Blending and transforming grids and images
+    grdinterpolate: Interpolate 2-D grids or 1-D series from a 3-D data cube
+    grdgdal: Execute GDAL raster programs from GMT
+
+New Core Module Features:
+
+    gmtspatial: -Sb computes buffers around lines (via optional GEOS library)
+    sample1d: Adds smoothing cubic spline via -Fs, with optional weights (-W)
+    gmtget: Options -D, -I, -N, -Q handle remote data set download and query
+    begin: Ignore user gmt.conf files normally included via -C
+    gmtregress: Let -A limit angles considered for LMS regression
+    grdconvert: Enable scaling/translation services with -Z
+    gmtvector: Add vector translate operator via -Tt
+    grdinfo: Now -C also appends registration
+    grdmath: New operators DAYNIGHT, BLEND, DOT, RGB2HSV, HSV2RGB
+    gmtmath: New operators RGB2HSV, HSV2RGB
+    grdfilter: Allow filter width units m|s. Let filter width be a grid with variable widths
+    grdcontour: Better handling of contour file with unique angles and pens per contour 
+    pscontour: Better handling of contour file with unique angles and pens per contour 
+    grdtrack: Determine peak in crossections with -F; let -E+c continue track if next line is a continuation of previous 
+    movie: Add -E for optional title sequence, -K for fade in and fade out, -Sb for PostScript layer, -P for progress indicators
+    surface: Let  -D take a modifier +z to set a constant breakline level
+    grdfill: Implement minimum-curvature spline infill with -Ac
+    grdgradient: Add support ambient light in -N, as in -E
+    grd2kml: New option -W for contour overlays
+
+Supplement updates:
+    seis: Update modules' syntax and make their i/o more robust
+    potential: grdflexure adds new transfer functions now documented with equations
+      </pre>
+</html>


### PR DESCRIPTION
This new file Release_6.1.html shows a raw list of changes in 6.1.  We can either keep it this way or add formatting.  In either case, need @seisman help to hook it into a news item for the release of 6.1.  So this is a WIP PR for now. I scraped the git history @seisman sent me to extract this list.  Both he and @joa-quim should examine this list and look for missed items.  Since file was > 10000 lines it is possible I clipped something.  I am not listing any of the bug-fixes, just features and modules.  There are many other things that could deserve a mention (CMake build improvements, for one), CI improvements, API additions, but most of those are not of interest to most.  Please add what you think should be added, and revise any entry that you feel is unclear.
