### PR TITLE
Don't use tags in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Push to genericmappingtools.github.io
         if: success() && github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v3
+        # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+        uses: peaceiris/actions-gh-pages@8a36f3edfc5d1cbae6b09e6f5a7d7b19e5b7a73b
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: GenericMappingTools/genericmappingtools.github.io


### PR DESCRIPTION
It's a security risk for actions that read encrypted secrets (variables):
https://julienrenaux.fr/2019/12/20/github-actions-security-risk/