### PR TITLE
List GMT mirrors in a separate page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -34,6 +34,7 @@ html_theme_options = {
         ("Home", "/", True),
         ("About", "about/", True),
         ("Download", "download/", True),
+        ("Mirrors", "mirrors/", True),
         ("Citing", "cite/", True),
         ("Documentation", "documentation/", True),
         ("Ecosystem", "projects/", True),

--- a/download/index.rst
+++ b/download/index.rst
@@ -21,25 +21,8 @@ Support Data
 * `GSHHG 2.3.7 <https://github.com/GenericMappingTools/gshhg-gmt/releases/download/2.3.7/gshhg-gmt-2.3.7.tar.gz>`__: The Global Self-consistent, Hierarchical, High-resolution Geography Database
 * `DCW 1.1.4 <https://github.com/GenericMappingTools/dcw-gmt/releases/download/1.1.4/dcw-gmt-1.1.4.tar.gz>`__: The Digital Chart of the World Data
 
-Mirrors
--------
-
-You may also get GMT and its support data from any of the GMT FTP mirrors.
+**Note:** You may also get GMT and its support data from any of :doc:`the GMT FTP mirrors </mirrors/index>`.
 Try the site that is closest to you to minimize transmission times.
-
-.. cssclass:: table-bordered
-
-=============================================================== =============================================================
-Site                                                            Address
-=============================================================== =============================================================
-SOEST, U. of Hawaii, US                                         ftp://ftp.soest.hawaii.edu/gmt
-Lab for Satellite Altimetry, NOAA, US                           ftp://ftp.star.nesdis.noaa.gov/pub/sod/lsa/gmt
-IRIS, Washington, US                                            ftp://ftp.iris.washington.edu/pub/gmt
-IAG-USP, U. of Sao Paulo, BRAZIL                                ftp://ftp.iag.usp.br/pub/gmt
-TENET, Tertiary Education & Research Networks, SOUTH AFRICA     ftp://gmt.mirror.ac.za/gmt
-Univ. of Sci. & Tech. of China, Hefei, CHINA                    http://mirrors.ustc.edu.cn/gmt
-Tokai U, Shizuoka, JAPAN                                        http://www.scc.u-tokai.ac.jp/gmt
-=============================================================== =============================================================
 
 Install
 -------

--- a/index.rst
+++ b/index.rst
@@ -263,6 +263,7 @@
 
    about/index.rst
    download/index.rst
+   mirrors/index.rst
    cite/index.rst
    projects/index.rst
    workshops/index.rst

--- a/mirrors/index.rst
+++ b/mirrors/index.rst
@@ -1,0 +1,42 @@
+.. title:: Mirrors
+
+Mirrors
+=======
+
+FTP Mirrors
+-----------
+
+The GMT FTP site hosts tarballs of GMT releases and its support data.
+Here is a list of the known active mirrors of the GMT FTP site.
+Try the site that is closest to you to minimize transmission times.
+
+.. cssclass:: table-bordered
+
+=============================================================== =============================================================
+Site                                                            Address
+=============================================================== =============================================================
+SOEST, U. of Hawaii, US                                         ftp://ftp.soest.hawaii.edu/gmt
+Lab for Satellite Altimetry, NOAA, US                           ftp://ftp.star.nesdis.noaa.gov/pub/sod/lsa/gmt
+IRIS, Washington, US                                            ftp://ftp.iris.washington.edu/pub/gmt
+IAG-USP, U. of Sao Paulo, BRAZIL                                ftp://ftp.iag.usp.br/pub/gmt
+TENET, Tertiary Education & Research Networks, SOUTH AFRICA     ftp://gmt.mirror.ac.za/gmt
+Univ. of Sci. & Tech. of China, Hefei, CHINA                    http://mirrors.ustc.edu.cn/gmt
+Tokai U, Shizuoka, JAPAN                                        http://www.scc.u-tokai.ac.jp/gmt
+=============================================================== =============================================================
+
+Data Server Mirrors
+-------------------
+
+The GMT data server stores frequently used data sets (e.g., Earth Releif Data).
+Here is a list of the known active mirrors of the GMT remote data server.
+Changing the GMT setting `GMT_DATA_SERVER <https://docs.generic-mapping-tools.org/latest/gmt.conf.html#term-GMT_DATA_SERVER>`_
+to the mirror that is closest to you to minimize transmission times.
+
+.. cssclass:: table-bordered
+
+================= =============================================================
+Name              Address
+================= =============================================================
+**Oceania**       https://oceania.generic-mapping-tools.org
+**Europe**        http://europe.generic-mapping-tools.org
+================= =============================================================


### PR DESCRIPTION
In this PR, I add a separate page/tab to list the mirrors of the GMT FTP site and data server. The "Downloads" page is also updated accordingly.

**Preview:** https://website-git-mirrors.gmt.vercel.app/

Please check the "Downloads" and "Mirrors" pages to see if you agree with these changes.

