### PR TITLE
Fix typo

### DIFF
--- a/about/index.rst
+++ b/about/index.rst
@@ -15,7 +15,7 @@ Council
 -------
 
 As of August 2016, GMT development and maintenance is being guided by a GMT Steering
-Committee, lead by Chair David Sandwell (Scripps) and members Dave Caress (MBARI),
+Committee, led by Chair David Sandwell (Scripps) and members Dave Caress (MBARI),
 Steve Diggs (Scripps), Dan Bassett (GNS Science, New Zealand), and Khalid Soofi (ConocoPhillips).
 
 


### PR DESCRIPTION
This PR fixes a small typo in which "lead" should be led". 