### PR TITLE
Add twitter icon and news announcement

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -69,12 +69,12 @@ html_theme_options = {
 html_context = {
     "social_links": [
         (
-            '<strong>Try Online!</strong>',
+            "<strong>Try Online!</strong>",
             "Try Online",
             "https://github.com/GenericMappingTools/try-gmt",
         ),
         (
-            '<strong>Forum</strong>',
+            "<strong>Forum</strong>",
             "Forum",
             "https://forum.generic-mapping-tools.org/",
         ),
@@ -82,6 +82,11 @@ html_context = {
             '<i class="fab fa-github fa-lg"></i>',
             "GitHub",
             "https://github.com/GenericMappingTools",
+        ),
+        (
+            '<i class="fab fa-twitter fa-lg"></i>',
+            "Twitter",
+            "https://twitter.com/gmt_dev",
         ),
         (
             '<i class="fab fa-youtube fa-lg"></i>',

--- a/index.rst
+++ b/index.rst
@@ -172,6 +172,10 @@
 
                <ul>
                <li>
+                  2021-03-15:
+                  We now have a Twitter handle <a href="https://twitter.com/gmt_dev">@gmt_dev</a>!
+               </li>
+               <li>
                   2021-02-15:
                   The third minor release of <a href="https://github.com/GenericMappingTools/pygmt/releases/tag/v0.3.0">PyGMT v0.3.0</a> is now available.
                </li>

--- a/index.rst
+++ b/index.rst
@@ -173,7 +173,7 @@
                <ul>
                <li>
                   2021-03-15:
-                  We now have a Twitter handle <a href="https://twitter.com/gmt_dev">@gmt_dev</a>!
+                  GMT now has a Twitter handle <a href="https://twitter.com/gmt_dev">@gmt_dev</a>!
                </li>
                <li>
                   2021-02-15:


### PR DESCRIPTION
Announce that we have a twitter handle (https://twitter.com/gmt_dev) on the News and add a Twitter icon link on the top-right.

Preview at https://website-git-fork-weiji14-twitter-gmt.vercel.app

![image](https://user-images.githubusercontent.com/23487320/111086768-fa820600-8582-11eb-92b8-a36ea0ca55c4.png)

Closes #99