### PR TITLE
Update release information for 6.2.0rc1

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -8,6 +8,7 @@ Documentation for GMT is available online in different versions (if in doubt, us
 
 * `Latest stable release <https://docs.generic-mapping-tools.org/latest>`__
 * `Current development version (unstable nightly builds) <https://docs.generic-mapping-tools.org/dev/>`__
+* `GMT 6.2.0rc1 <https://docs.generic-mapping-tools.org/6.2.0rc1/>`__
 * `GMT 6.1.1 <https://docs.generic-mapping-tools.org/6.1/>`__
 * `GMT 6.0.0 <https://docs.generic-mapping-tools.org/6.0/>`__
 * `GMT 5.4.5 <https://docs.generic-mapping-tools.org/5.4/>`__

--- a/download/index.rst
+++ b/download/index.rst
@@ -9,6 +9,7 @@ Releases
 GMT is available on Windows, macOS, Linux and FreeBSD. Source and binary packages are provided
 from `GitHub <https://github.com/GenericMappingTools/gmt/releases>`__:
 
+* `GMT 6.2.0rc1 (release candidate) <https://github.com/GenericMappingTools/gmt/releases/tag/6.2.0rc1>`__
 * `GMT 6.1.1 <https://github.com/GenericMappingTools/gmt/releases/tag/6.1.1>`__ (**recommended**)
 * `GMT 6.1.0 <https://github.com/GenericMappingTools/gmt/releases/tag/6.1.0>`__
 * `GMT 6.0.0 <https://github.com/GenericMappingTools/gmt/releases/tag/6.0.0>`__

--- a/index.rst
+++ b/index.rst
@@ -226,6 +226,10 @@
 
                <ul>
                <li>
+                  2021-04-20:
+                  <a href="https://github.com/GenericMappingTools/gmt/releases/tag/6.2.0rc1">GMT 6.2.0 Release Candidate 1</a>
+               </li>
+               <li>
                   2020-09-02:
                   <a href="https://github.com/GenericMappingTools/gmt/releases/tag/6.1.1">GMT 6.1.1</a>
                </li>


### PR DESCRIPTION
Include links to GMT 6.2.0 release candidate 1. Xref https://github.com/GenericMappingTools/gmt/issues/5070