### PR TITLE
Highlight wrappers in the summary paragraph

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -37,6 +37,10 @@
             <i class="fab fa-discourse"></i> GMT Community Forum</a> to get help
             and connect with other users and developers.
             </p>
+            <p>
+            <strong>Want to use GMT in MATLAB/Octave, Julia, or Python?</strong>
+            Check out the <a href="https://www.generic-mapping-tools.org/projects/#gmt-interfaces">GMT interfaces</a>!
+            </p>
 
             </div>
            <div class="col-sm-5 col-sm-pull-7">


### PR DESCRIPTION
This PR adds a sentence about the wrappers in the first summary paragraph on the website landing page. I think this prominence is helpful, since some people may not scroll all the way to the "C, MATLAB, Julia, Python section". Comments are welcome. Here is what the change looks like:

<img width="1663" alt="image" src="https://user-images.githubusercontent.com/14077947/115622051-5a2ba980-a2c5-11eb-9942-08651a3042c2.png">

Preview link: https://website-3101vnw0c-gmt.vercel.app/
