### PR TITLE
Move older news from front page to news page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -189,37 +189,6 @@
                   2020-09-02:
                   GMT 6.1.1 has been released.  See  <a href="https://forum.generic-mapping-tools.org/t/gmt-6-1-1-has-been-released/839">the announcement</a> for details.
                </li>
-               <li>
-                  2020-07-04:
-                  GMT 6.1.0 has been released.  See  <a href="https://forum.generic-mapping-tools.org/t/gmt-6-1-0-has-been-released/619">the announcement</a> for details.
-               </li>
-               <li>
-                  2020-06-23:
-                  <b>GMT postdoctoral position</b> available at SOEST, U of Hawaii at Mānoa.
-                  Click to
-                  <a target="_blank" href="https://docs.google.com/document/d/15-ksiUotquaNYVnnpy8NKIWNU8pGPduf8__jZLSvGQE/edit?usp=sharing"> view ad details</a>
-                  or
-                  <a target="_blank" href="https://hcmweb.rcuh.com/psp/hcmprd_exapp/EMPLOYEE/HRMS/c/HRS_HRAM.HRS_APP_SCHJOB.GBL?Page=HRS_APP_JBPST&Action=U&FOCUS=Applicant&SiteId=3&JobOpeningId=220288&PostingSeq=1">apply online now</a>!
-               </li>
-               <li>
-                  2020-03-30:
-                  NSF-EAR grant
-                  <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1948602">number 1948602</a>
-                  awarded to fund efforts to make GMT truly sustainable by its community.
-               </li>
-               <li>
-                  2019-11-04:
-                  Paul Wessel is the recipient of the 2020 European Geosciences Union
-                  <a href="https://www.egu.eu/awards-medals/ian-mcharg/">Ian McHarg Medal</a>
-                  for his work on GMT.
-                  Read more about it in the
-                  <a href="https://www.soest.hawaii.edu/soestwp/announce/news/paul-wessel-honored-for-distinguished-research/">SOEST announcement</a>
-                  and <a href="https://www.egu.eu/news/545/egu-announces-2020-awards-and-medals/">EGU 2020 awards recipients list</a>.
-               </li>
-               <li>
-                  2019-11-01:
-                  The <a href="https://doi.org/10.1029/2019GC008515">paper for GMT 6</a> is Open Access and available on <i>Geochemistry, Geophysics, Geosystems</i>.
-               </li>
                </ul>
 
                <p>
@@ -261,7 +230,7 @@
                <h2>Upcoming workshops</h2>
 
                <ul>
-               <li><strong>2021</strong>: The Generic Mapping Tools for Geodesy.</li>
+               <li>2021-07: The Generic Mapping Tools for Geodesy.</li>
                </ul>
 
                <p>

--- a/news/index.rst
+++ b/news/index.rst
@@ -3,8 +3,12 @@
 News
 ====
 
-- NSF-EAR grant `number 1948602 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1948602>`__
+- 2020-03-20: NSF-EAR grant `number 1948602 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1948602>`__
   awarded to fund efforts to make GMT truly sustainable by its community!
-- NSF-EAR grant `number 1829371 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1829371>`__
+- 2019-11-04: Paul Wessel is the recipient of the 2020 European Geosciences Union `Ian McHarg Medal <https://www.egu.eu/awards-medals/ian-mcharg/>`__
+  for his work on GMT. Read more about it in the `SOEST announcement <https://www.soest.hawaii.edu/soestwp/announce/news/paul-wessel-honored-for-distinguished-research/>`__
+  and `EGU 2020 awards recipients list <https://www.egu.eu/news/545/egu-announces-2020-awards-and-medals/>`__.
+- 2019-11-01: The `paper for GMT 6 <https://doi.org/10.1029/2019GC008515>`__ is Open Access and available on *Geochemistry, Geophysics, Geosystems*.
+- 2018-08-17: NSF-EAR grant `number 1829371 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1829371>`__
   awarded to fund development of the new "modern mode" in GMT 6 and more!
-- Paul and Leo were `interviewed on the Don't Panic Geocast <http://www.dontpanicgeocast.com/?p=638>`__.
+- 2018-04-27: Paul and Leo were `interviewed on the Don't Panic Geocast <https://www.dontpanicgeocast.com/166>`__.


### PR DESCRIPTION
This PR migrates some of the older news items from the landing page to the news page, because the list was getting long relative to the releases and workshops lists.

Based on the conversation at https://github.com/GenericMappingTools/website/pull/95, I removed rather than migrated the news about the release of 6.1.0 and postdoc advertisement.