### PR TITLE
Update name for OpenTopography mirror to match address

### DIFF
--- a/mirrors/index.rst
+++ b/mirrors/index.rst
@@ -64,7 +64,7 @@ to the mirror that is closest to you to minimize transmission times.
      - http://china.generic-mapping-tools.org
      - U of Sci. & Tech. of China, China
      - .. image:: https://img.shields.io/website?down_message=offline&label=%20&style=plastic&up_message=OK&url=http%3A%2F%2Fchina.generic-mapping-tools.org/gmt_data_server.txt
-   * - **OpenTopography/SDSC** [US West Coast]
+   * - **sdsc-opentopography** [US West Coast]
      - http://sdsc-opentopography.generic-mapping-tools.org
      - OpenTopography at San Diego Supercomputing Center
      - .. image:: https://img.shields.io/website?down_message=offline&label=%20&style=plastic&up_message=OK&url=http%3A%2F%2Fsdsc-opentopography.generic-mapping-tools.org/gmt_data_server.txt


### PR DESCRIPTION
This PR updates the name of the OpenTopography mirror to match the format expected by the GMT_DATA_SERVER setting.