### PR TITLE
Move to 6.4

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -8,6 +8,7 @@ Documentation for GMT is available online in different versions (if in doubt, us
 
 * `Latest stable release <https://docs.generic-mapping-tools.org/latest>`__
 * `Current development version (unstable nightly builds) <https://docs.generic-mapping-tools.org/dev/>`__
+* `GMT 6.4.0 <https://docs.generic-mapping-tools.org/6.4/>`__
 * `GMT 6.3.0 <https://docs.generic-mapping-tools.org/6.3/>`__
 * `GMT 6.2.0 <https://docs.generic-mapping-tools.org/6.2/>`__
 * `GMT 6.1.1 <https://docs.generic-mapping-tools.org/6.1/>`__

--- a/download/index.rst
+++ b/download/index.rst
@@ -12,7 +12,8 @@ GMT Releases
 GMT is available on Windows, macOS, Linux and FreeBSD. Source and binary packages are provided
 from `GitHub <https://github.com/GenericMappingTools/gmt/releases>`__:
 
-* `GMT 6.3.0 <https://github.com/GenericMappingTools/gmt/releases/tag/6.3.0>`__ (**recommended**)
+* `GMT 6.4.0 <https://github.com/GenericMappingTools/gmt/releases/tag/6.4.0>`__ (**recommended**)
+* `GMT 6.3.0 <https://github.com/GenericMappingTools/gmt/releases/tag/6.3.0>`__
 * `GMT 6.2.0 <https://github.com/GenericMappingTools/gmt/releases/tag/6.2.0>`__
 * `GMT 6.1.1 <https://github.com/GenericMappingTools/gmt/releases/tag/6.1.1>`__
 * `GMT 6.1.0 <https://github.com/GenericMappingTools/gmt/releases/tag/6.1.0>`__


### PR DESCRIPTION
Update website following 6.4 release.  Note the checklist says to update the news section but I think we stopped adding those items as we have the auto-generated glyphs showing the latest ?