### PR TITLE
Move AGU24 preworkshop from upcoming to past workshops

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -176,9 +176,14 @@
 
                <ul>
                <li>
+                  2024-12-09:
+                  The GMT team organized the Union Session "The impact of GMT in the Earth, Ocean and Space sciences: What's next?" (U12B and U13B)
+                  at the AGU Annual Meeting in Washington, DC, 2024 with talks and posters on GMT, the wrappers, and related topics.
+               </li>
+               <li>
                   2024-12-08:
                   The GMT and PyGMT teams organised the pre-conference workshop "Mastering Geospatial Visualizations with GMT/PyGMT" (PREWS9)
-                  at AGU Annual Meeting in Washington, DC, 2024.
+                  at the AGU Annual Meeting in Washington, DC, 2024.
                </li>
                <li>
                   2023-08-17:

--- a/index.rst
+++ b/index.rst
@@ -205,9 +205,6 @@
             <div class="col-sm-4 front-block-text">
                <h2>Upcoming workshops</h2>
 
-               <ul>
-
-               </ul>
 
                <p>
                <a href="/workshops#future-workshops">more »</a>

--- a/index.rst
+++ b/index.rst
@@ -176,6 +176,11 @@
 
                <ul>
                <li>
+                  2024-12-08:
+                  The GMT and PyGMT teams organised the pre-conference workshop "Mastering Geospatial Visualizations with GMT/PyGMT" (PREWS9)
+                  at AGU Annual Meeting in Washington, DC, 2024.
+               </li>
+               <li>
                   2023-08-17:
                   The GMT developer team finally was able to have a GMT Summit, this time in Oslo over July 17-21, 2023.
                </li>
@@ -201,7 +206,7 @@
                <h2>Upcoming workshops</h2>
 
                <ul>
-               <li>2024-12-08: Mastering Geospatial Visualizations with GMT/PyGMT at AGU Fall Meeting 2024.</li>
+
                </ul>
 
                <p>

--- a/workshops/index.rst
+++ b/workshops/index.rst
@@ -16,8 +16,18 @@ Attending a workshop is the best way to get started **using and developing** GMT
 Upcoming Workshops
 ------------------
 
-2024-12-08 | Mastering Geospatial Visualizations with GMT/PyGMT at AGU Fall Meeting 2024
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. raw:: html
+
+   <hr style="margin: 80px 0px;">
+
+
+.. _past_workshops:
+
+Past Workshops
+--------------
+
+2024-12-08 | Mastering Geospatial Visualizations with GMT/PyGMT at AGU Annual Meeting 2024
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 * **Title:** Mastering Geospatial Visualizations with GMT/PyGMT (PREWS9)
 * **Instructors:** Wei Ji Leong, Yvonne Fröhlich, Jing-Hui Tong, Federico Esteban, Max Jones, Andre Luiz Belem
@@ -46,16 +56,6 @@ community to join. The focus of this workshop is to develop skills on using free
 open source software, coding, data manipulation and visualization. Learn to produce
 publication-ready figures, especially geographic maps, using PyGMT including the
 integration with the PyData ecosystem.
-
-.. raw:: html
-
-   <hr style="margin: 80px 0px;">
-
-
-.. _past_workshops:
-
-Past Workshops
---------------
 
 2023-06-26 | GMT for Geodesy EarthScope
 +++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
This PR moves the AGU24 GMT/PyGMT pre-conference workshop from "upcoming" to "past" workshops (https://www.generic-mapping-tools.org/workshops/).

Just wondering, if we should list the Union Session on GMT also somewhere?

Patches: #155