### PR TITLE
Citing GMT: Add single releases with their zenodo DOIs

### DIFF
--- a/cite/index.rst
+++ b/cite/index.rst
@@ -9,7 +9,7 @@ illustrations obtained using GMT. **When in doubt, please cite the latest paper.
 Futhuremore, you are welcome to cite the specific version you have used in your work.
 
 GMT versions:
-* **latest / all GMT version**: https://doi.org/10.5281/zenodo.3407865
+* **latest / all GMT versions**: https://doi.org/10.5281/zenodo.3407865
 
 * **GMT 6.6.0**:
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., Esteban, F., & Fröhlich, Y. (2025).

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -14,42 +14,42 @@ GMT versions:
 * **GMT 6.6.0**: [![DOI for GMT v6.6.0](https://zenodo.org/badge/DOI/10.5281/zenodo.16448627.svg)](https://doi.org/10.5281/zenodo.16448627)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., Esteban, F., & Fröhlich, Y. (2025).
   The Generic Mapping Tools version 6.6.0.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.16448627
 * **GMT 6.5.0**: [![DOI for GMT 6.5.0](https://zenodo.org/badge/DOI/10.5281/zenodo.10119499.svg)](https://doi.org/10.5281/zenodo.10119499)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2024).
   The Generic Mapping Tools version 6.5.0.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.10119499
 * **GMT 6.4.0**: [![DOI for GMT 6.4.0](https://zenodo.org/badge/DOI/10.5281/zenodo.6623271.svg)](https://doi.org/10.5281/zenodo.6623271)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2022).
   The Generic Mapping Tools version 6.4.0.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.6623271
 * **GMT 6.3.0**: [![DOI for GMT 6.3.0](https://zenodo.org/badge/DOI/10.5281/zenodo.5708769.svg)](https://doi.org/10.5281/zenodo.5708769)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2021).
   The Generic Mapping Tools version 6.3.0.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.5708769
 * **GMT 6.2.0**: [![DOI for GMT 6.2.0](https://zenodo.org/badge/DOI/10.5281/zenodo.4900001.svg)](https://doi.org/10.5281/zenodo.4900001)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2021).
   The Generic Mapping Tools version 6.2.0.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.4900001
 * **GMT 6.1.1**: [![DOI for GMT 6.1.1](https://zenodo.org/badge/DOI/10.5281/zenodo.4010996.svg)](https://doi.org/10.5281/zenodo.4010996)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020). 
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
   The Generic Mapping Tools version 6.1.1.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.4010996
 * **GMT 6.1**: [![DOI for GMT 6.1](https://zenodo.org/badge/DOI/10.5281/zenodo.3924517.svg)](https://doi.org/10.5281/zenodo.3924517)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
   The Generic Mapping Tools version 6.1.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.3924517
 * **GMT 6**: [![DOI for GMT 6](https://zenodo.org/badge/DOI/10.5281/zenodo.3407866.svg)](https://doi.org/10.5281/zenodo.3407866)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2019).
   The Generic Mapping Tools version 6.
-  *Zenodo*
+  *Zenodo*.
   https://doi.org/10.5281/zenodo.3407866
 
 The articles on GMT are:

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -9,13 +9,48 @@ illustrations obtained using GMT. **When in doubt, please cite the latest paper.
 Futhuremore, you are welcome to cite the specific version you have used in your work.
 
 GMT versions:
-* **latest / all GMT versions**: https://doi.org/10.5281/zenodo.3407865
 
+* **latest / all GMT versions**: https://doi.org/10.5281/zenodo.3407865
 * **GMT 6.6.0**:
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., Esteban, F., & Fröhlich, Y. (2025).
   The Generic Mapping Tools version 6.6.0.
   *Zenodo*
   https://doi.org/10.5281/zenodo.16448627
+* **GMT 6.5.0**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2024).
+  The Generic Mapping Tools version 6.5.0.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.10119499
+* **GMT 6.4.0**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2022).
+  The Generic Mapping Tools version 6.4.0.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.6623271
+* **GMT 6.3.0**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2021).
+  The Generic Mapping Tools version 6.3.0.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.5708769
+* **GMT 6.2.0**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2021).
+  The Generic Mapping Tools version 6.2.0.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.4900001
+* **GMT 6.1.1**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
+  The Generic Mapping Tools version 6.1.1.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.4010996
+* **GMT 6.1**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
+  The Generic Mapping Tools version 6.1.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.3924517
+* **GMT 6**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2019).
+  The Generic Mapping Tools version 6.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.3407866
 
 The articles on GMT are:
 

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -6,6 +6,15 @@ Citing GMT
 If you feel it is appropriate, you may consider paying us back by citing our articles on
 GMT and technical papers on algorithms when you publish papers containing results or
 illustrations obtained using GMT. **When in doubt, please cite the latest paper.**
+Futhuremore, you are welcome to cite the specific version you have used in your work.
+
+GMT versions:
+
+* **GMT 6.6.0**:
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., Esteban, F., & Fröhlich, Y. (2025).
+  The Generic Mapping Tools version 6.6.0.
+  *Zenodo*
+  https://doi.org/10.5281/zenodo.16448627
 
 The articles on GMT are:
 
@@ -20,9 +29,9 @@ The articles on GMT are:
   *Geochemistry, Geophysics, Geosystems*, 25(6).
   https://doi.org/10.1029/2024GC011545
 * **Origin of GMT**:
-  Wessel, P. (2024). 
-  The origins of the generic mapping tools: From table tennis to geoscience. 
-  *Perspectives of Earth and Space Scientists*, 5(1), e2023CN000231. 
+  Wessel, P. (2024).
+  The origins of the generic mapping tools: From table tennis to geoscience.
+  *Perspectives of Earth and Space Scientists*, 5(1), e2023CN000231.
   https://doi.org/10.1029/2023CN000231
 * **GMT/MATLAB**:
   Wessel, P., & Luis, J. F. (2017).

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -12,45 +12,13 @@ GMT versions:
 
 * **latest / all GMT versions**: [![DOI for latest / all GMT versions](https://zenodo.org/badge/DOI/10.5281/zenodo.3407865.svg)](https://doi.org/10.5281/zenodo.3407865)
 * **GMT 6.6.0**: [![DOI for GMT v6.6.0](https://zenodo.org/badge/DOI/10.5281/zenodo.16448627.svg)](https://doi.org/10.5281/zenodo.16448627)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., Esteban, F., & Fröhlich, Y. (2025).
-  The Generic Mapping Tools version 6.6.0.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.16448627
 * **GMT 6.5.0**: [![DOI for GMT 6.5.0](https://zenodo.org/badge/DOI/10.5281/zenodo.10119499.svg)](https://doi.org/10.5281/zenodo.10119499)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2024).
-  The Generic Mapping Tools version 6.5.0.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.10119499
 * **GMT 6.4.0**: [![DOI for GMT 6.4.0](https://zenodo.org/badge/DOI/10.5281/zenodo.6623271.svg)](https://doi.org/10.5281/zenodo.6623271)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2022).
-  The Generic Mapping Tools version 6.4.0.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.6623271
 * **GMT 6.3.0**: [![DOI for GMT 6.3.0](https://zenodo.org/badge/DOI/10.5281/zenodo.5708769.svg)](https://doi.org/10.5281/zenodo.5708769)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2021).
-  The Generic Mapping Tools version 6.3.0.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.5708769
 * **GMT 6.2.0**: [![DOI for GMT 6.2.0](https://zenodo.org/badge/DOI/10.5281/zenodo.4900001.svg)](https://doi.org/10.5281/zenodo.4900001)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2021).
-  The Generic Mapping Tools version 6.2.0.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.4900001
 * **GMT 6.1.1**: [![DOI for GMT 6.1.1](https://zenodo.org/badge/DOI/10.5281/zenodo.4010996.svg)](https://doi.org/10.5281/zenodo.4010996)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
-  The Generic Mapping Tools version 6.1.1.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.4010996
 * **GMT 6.1**: [![DOI for GMT 6.1](https://zenodo.org/badge/DOI/10.5281/zenodo.3924517.svg)](https://doi.org/10.5281/zenodo.3924517)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
-  The Generic Mapping Tools version 6.1.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.3924517
 * **GMT 6**: [![DOI for GMT 6](https://zenodo.org/badge/DOI/10.5281/zenodo.3407866.svg)](https://doi.org/10.5281/zenodo.3407866)
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2019).
-  The Generic Mapping Tools version 6.
-  *Zenodo*.
-  https://doi.org/10.5281/zenodo.3407866
 
 The articles on GMT are:
 

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -9,6 +9,7 @@ illustrations obtained using GMT. **When in doubt, please cite the latest paper.
 Futhuremore, you are welcome to cite the specific version you have used in your work.
 
 GMT versions:
+* **latest / all GMT version**: https://doi.org/10.5281/zenodo.3407865
 
 * **GMT 6.6.0**:
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., Esteban, F., & Fröhlich, Y. (2025).

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -6,7 +6,7 @@ Citing GMT
 If you feel it is appropriate, you may consider paying us back by citing our articles on
 GMT and technical papers on algorithms when you publish papers containing results or
 illustrations obtained using GMT. **When in doubt, please cite the latest paper.**
-Futhuremore, you are welcome to cite the specific version you have used in your work.
+Furthermore, you are welcome to cite the specific version you have used in your work.
 
 GMT versions:
 

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -10,43 +10,43 @@ Futhuremore, you are welcome to cite the specific version you have used in your 
 
 GMT versions:
 
-* **latest / all GMT versions**: https://doi.org/10.5281/zenodo.3407865
-* **GMT 6.6.0**:
+* **latest / all GMT versions**: [![DOI for latest / all GMT versions](https://zenodo.org/badge/DOI/10.5281/zenodo.3407865.svg)](https://doi.org/10.5281/zenodo.3407865)
+* **GMT 6.6.0**: [![DOI for GMT v6.6.0](https://zenodo.org/badge/DOI/10.5281/zenodo.16448627.svg)](https://doi.org/10.5281/zenodo.16448627)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., Esteban, F., & Fröhlich, Y. (2025).
   The Generic Mapping Tools version 6.6.0.
   *Zenodo*
   https://doi.org/10.5281/zenodo.16448627
-* **GMT 6.5.0**:
+* **GMT 6.5.0**: [![DOI for GMT 6.5.0](https://zenodo.org/badge/DOI/10.5281/zenodo.10119499.svg)](https://doi.org/10.5281/zenodo.10119499)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2024).
   The Generic Mapping Tools version 6.5.0.
   *Zenodo*
   https://doi.org/10.5281/zenodo.10119499
-* **GMT 6.4.0**:
+* **GMT 6.4.0**: [![DOI for GMT 6.4.0](https://zenodo.org/badge/DOI/10.5281/zenodo.6623271.svg)](https://doi.org/10.5281/zenodo.6623271)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2022).
   The Generic Mapping Tools version 6.4.0.
   *Zenodo*
   https://doi.org/10.5281/zenodo.6623271
-* **GMT 6.3.0**:
+* **GMT 6.3.0**: [![DOI for GMT 6.3.0](https://zenodo.org/badge/DOI/10.5281/zenodo.5708769.svg)](https://doi.org/10.5281/zenodo.5708769)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., Tian, D., Jones, M., & Esteban, F. (2021).
   The Generic Mapping Tools version 6.3.0.
   *Zenodo*
   https://doi.org/10.5281/zenodo.5708769
-* **GMT 6.2.0**:
+* **GMT 6.2.0**: [![DOI for GMT 6.2.0](https://zenodo.org/badge/DOI/10.5281/zenodo.4900001.svg)](https://doi.org/10.5281/zenodo.4900001)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2021).
   The Generic Mapping Tools version 6.2.0.
   *Zenodo*
   https://doi.org/10.5281/zenodo.4900001
-* **GMT 6.1.1**:
-  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
+* **GMT 6.1.1**: [![DOI for GMT 6.1.1](https://zenodo.org/badge/DOI/10.5281/zenodo.4010996.svg)](https://doi.org/10.5281/zenodo.4010996)
+  Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020). 
   The Generic Mapping Tools version 6.1.1.
   *Zenodo*
   https://doi.org/10.5281/zenodo.4010996
-* **GMT 6.1**:
+* **GMT 6.1**: [![DOI for GMT 6.1](https://zenodo.org/badge/DOI/10.5281/zenodo.3924517.svg)](https://doi.org/10.5281/zenodo.3924517)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2020).
   The Generic Mapping Tools version 6.1.
   *Zenodo*
   https://doi.org/10.5281/zenodo.3924517
-* **GMT 6**:
+* **GMT 6**: [![DOI for GMT 6](https://zenodo.org/badge/DOI/10.5281/zenodo.3407866.svg)](https://doi.org/10.5281/zenodo.3407866)
   Wessel, P., Luis, J. F., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2019).
   The Generic Mapping Tools version 6.
   *Zenodo*

--- a/cite/index.rst
+++ b/cite/index.rst
@@ -10,15 +10,41 @@ Futhuremore, you are welcome to cite the specific version you have used in your 
 
 GMT versions:
 
-* **latest / all GMT versions**: [![DOI for latest / all GMT versions](https://zenodo.org/badge/DOI/10.5281/zenodo.3407865.svg)](https://doi.org/10.5281/zenodo.3407865)
-* **GMT 6.6.0**: [![DOI for GMT v6.6.0](https://zenodo.org/badge/DOI/10.5281/zenodo.16448627.svg)](https://doi.org/10.5281/zenodo.16448627)
-* **GMT 6.5.0**: [![DOI for GMT 6.5.0](https://zenodo.org/badge/DOI/10.5281/zenodo.10119499.svg)](https://doi.org/10.5281/zenodo.10119499)
-* **GMT 6.4.0**: [![DOI for GMT 6.4.0](https://zenodo.org/badge/DOI/10.5281/zenodo.6623271.svg)](https://doi.org/10.5281/zenodo.6623271)
-* **GMT 6.3.0**: [![DOI for GMT 6.3.0](https://zenodo.org/badge/DOI/10.5281/zenodo.5708769.svg)](https://doi.org/10.5281/zenodo.5708769)
-* **GMT 6.2.0**: [![DOI for GMT 6.2.0](https://zenodo.org/badge/DOI/10.5281/zenodo.4900001.svg)](https://doi.org/10.5281/zenodo.4900001)
-* **GMT 6.1.1**: [![DOI for GMT 6.1.1](https://zenodo.org/badge/DOI/10.5281/zenodo.4010996.svg)](https://doi.org/10.5281/zenodo.4010996)
-* **GMT 6.1**: [![DOI for GMT 6.1](https://zenodo.org/badge/DOI/10.5281/zenodo.3924517.svg)](https://doi.org/10.5281/zenodo.3924517)
-* **GMT 6**: [![DOI for GMT 6](https://zenodo.org/badge/DOI/10.5281/zenodo.3407866.svg)](https://doi.org/10.5281/zenodo.3407866)
+* **latest / all GMT versions**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3407865.svg
+  :target: https://doi.org/10.5281/zenodo.3407865
+
+* **GMT 6.6.0**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.16448627.svg
+  :target: https://doi.org/10.5281/zenodo.16448627
+
+* **GMT 6.5.0**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10119499.svg
+  :target: https://doi.org/10.5281/zenodo.10119499
+
+* **GMT 6.4.0**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.6623271.svg
+  :target: https://doi.org/10.5281/zenodo.6623271
+
+* **GMT 6.3.0**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5708769.svg
+  :target: https://doi.org/10.5281/zenodo.5708769
+
+* **GMT 6.2.0**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4900001.svg
+  :target: https://doi.org/10.5281/zenodo.4900001
+
+* **GMT 6.1.1**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4010996.svg
+  :target: https://doi.org/10.5281/zenodo.4010996
+
+* **GMT 6.1**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3924517.svg
+  :target: https://doi.org/10.5281/zenodo.3924517
+
+* **GMT 6**
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3407866.svg
+  :target: https://doi.org/10.5281/zenodo.3407866
 
 The articles on GMT are:
 


### PR DESCRIPTION
Following this post on the GMT forum, https://forum.generic-mapping-tools.org/t/citation-information-add-doi-for-code-base-citation/6401 this PR tests / proposes to add the single GMT releases with their zenodo DOIs (https://doi.org/10.5281/zenodo.3407865) to the "Citing GMT" website page (https://www.generic-mapping-tools.org/cite/).