### PR TITLE
Fix carousel and other Bootstrap JS plugins broken by jQuery noConfli…

### DIFF
--- a/_static/js/jquery-fix.js
+++ b/_static/js/jquery-fix.js
@@ -1,0 +1,15 @@
+// Override of sphinx_bootstrap_theme's bundled jquery-fix.js.
+//
+// The theme loads scripts in this order: jquery, jquery-fix.js,
+// bootstrap.min.js, bootstrap-sphinx.js. The upstream jquery-fix.js calls
+// jQuery.noConflict(true), which removes *both* window.jQuery and window.$
+// before bootstrap.min.js runs. bootstrap.min.js grabs the global `jQuery`
+// symbol to attach its plugins (carousel, dropdown, collapse, ...), so it
+// crashes immediately and none of them get attached - breaking, among other
+// things, the front-page carousel (GenericMappingTools/website#146).
+//
+// Calling noConflict() without `true` only releases the `$` alias and keeps
+// window.jQuery defined, so bootstrap.min.js still works. bootstrap-sphinx.js
+// already prefers window.$jqTheme, so behavior for the theme's own script is
+// unchanged.
+window.$jqTheme = jQuery.noConflict();


### PR DESCRIPTION
The theme's bundled `jquery-fix.js` calls `jQuery.noConflict(true)` before `bootstrap.min.js` loads, wiping `window.jQuery` and breaking every Bootstrap JS plugin (carousel, dropdowns, ...).

This overrides that file (Sphinx lets project static files shadow theme static files) to use `noConflict()` instead, which keeps `window.jQuery` defined for `bootstrap.min.js` while leaving `bootstrap-sphinx.js`'s behavior unchanged.

Verified locally with `sphinx-build`: no more console error, and the carousel auto-advances and responds to manual prev/next/indicator clicks.

Fixes #146

**Done with Sonnet 5**